### PR TITLE
Fix load discriminators when finetune

### DIFF
--- a/speechtokenizer/trainer/trainer.py
+++ b/speechtokenizer/trainer/trainer.py
@@ -244,11 +244,12 @@ class SpeechTokenizerTrainer(nn.Module):
         if not exists(path):
             ckpts = sorted(self.results_folder.glob(f'SpeechTokenizerTrainer_*'))
             path = str(ckpts[-1])
-        generator = self.accelerator.unwrap_model(self.generator)
         pkg = torch.load(path, map_location='cpu')
+        generator = self.accelerator.unwrap_model(self.generator)
         generator.load_state_dict(pkg['generator'])
-        discriminators = {k:self.accelerator.unwrap_model(v) for k, v in self.discriminators.items()}
-        map(lambda kv: kv[1].load_state_dict(pkg['discriminators'][kv[0]]), discriminators.items())
+        for k, discriminator in self.discriminators.items():
+            discriminator = self.accelerator.unwrap_model(discriminator)
+            discriminator.load_state_dict(pkg['discriminators'][k])
 
         if restore_optimizer:
             self.optim_d.load_state_dict(pkg['optim_d'])


### PR DESCRIPTION
When I try to fine-tune your model, there seems to be a problem with loading the discriminators.

Loss before fine-tuning:
Epoch 50 -- Step 110000: Gen Loss: 24.994; Mel Error: 0.234; Recon Error: 0.007; **Feature Error: 4.705; Adversarial Error: 5.280**; Time per step: 0.919s

Loss during fine-tuning:
Epoch 0 -- Step 110010: Gen Loss: 23.484; Mel Error: 0.231; Recon Error: 0.009; **Feature Error: 0.087; Adversarial Error: 7.695**; Time per step: 1.066s